### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,5 +1,8 @@
 name: Publish to VS Code Marketplace
 
+permissions:
+  contents: write
+
 on:
   release:
     types: [published]


### PR DESCRIPTION
Potential fix for [https://github.com/kumpeapps/git-quickops/security/code-scanning/1](https://github.com/kumpeapps/git-quickops/security/code-scanning/1)

In general, the fix is to add a `permissions` block that grants only the scopes this workflow needs. Because it uploads release assets using `softprops/action-gh-release`, it requires `contents: write`. Other steps either use repository contents (which are covered by `contents`) or external services (VS Code Marketplace via a PAT), and don’t need other GitHub scopes.

The best minimal fix without changing functionality is to add a workflow-level `permissions` block right after the `name` (or before `on:`) in `.github/workflows/publish.yml`. This block should specify `contents: write`, which implicitly allows reading contents as well. No other permissions are necessary from the shown code. No additional imports or dependencies are needed since this is just YAML configuration.

Concretely, in `.github/workflows/publish.yml`, after line 1 (`name: Publish to VS Code Marketplace`), insert:

```yaml
permissions:
  contents: write
```

leaving the rest of the workflow unchanged.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

CI:
- Add a workflow-level permissions block to the VS Code Marketplace publish workflow limiting access to contents: write.