### PR TITLE
[bug/4] Resolved staged filenames droping first character of filename

### DIFF
--- a/src/gitUtils.ts
+++ b/src/gitUtils.ts
@@ -48,7 +48,7 @@ export async function execGit(cwd: string, args: string[]): Promise<string> {
             if (error) {
                 reject(new Error(stderr || error.message));
             } else {
-                resolve(stdout.trim());
+                resolve(stdout.trimEnd());
             }
         });
     });

--- a/src/webviewProvider.ts
+++ b/src/webviewProvider.ts
@@ -459,11 +459,11 @@ export class GitQuickOpsWebviewProvider implements vscode.WebviewViewProvider {
         const staged = lines
             .filter(l => l.charAt(0) !== ' ' && l.charAt(0) !== '?')
             .map(l => {
-                // Git status format: "XY filename" 
-                // X = index status (position 0), Y = worktree status (position 1)
-                // Position 2 is space, filename starts at position 3
-                const statusChar = l.charAt(0);
-                const filePath = l.slice(3); // Get everything from position 3 onwards
+                // Git status format: "XY filename" where X and Y are status chars
+                // Use trimStart to handle any leading whitespace, then skip 2 status chars + space
+                const trimmed = l.trimStart();
+                const statusChar = trimmed.charAt(0);
+                const filePath = trimmed.slice(2).trim();
                 return {
                     status: statusChar,
                     path: filePath
@@ -473,8 +473,10 @@ export class GitQuickOpsWebviewProvider implements vscode.WebviewViewProvider {
         const unstaged = lines
             .filter(l => l.charAt(1) !== ' ' || l.charAt(0) === '?')
             .map(l => {
-                const statusChar = l.charAt(1) !== ' ' ? l.charAt(1) : l.charAt(0);
-                const filePath = l.slice(3);
+                // Use trimStart to handle any leading whitespace, then parse status and filename  
+                const trimmed = l.trimStart();
+                const statusChar = trimmed.charAt(1) !== ' ' ? trimmed.charAt(1) : trimmed.charAt(0);
+                const filePath = trimmed.slice(2).trim();
                 return {
                     status: statusChar,
                     path: filePath


### PR DESCRIPTION
resolves #4

## Summary by Sourcery

Fix parsing of git status output to correctly capture full staged and unstaged file paths and adjust git command output trimming.

Bug Fixes:
- Correct staged file path parsing so filenames are no longer missing their first character when reading git status output.
- Fix unstaged file path parsing to be robust against leading whitespace in git status lines.

Enhancements:
- Adjust git command output handling to preserve leading whitespace while trimming trailing newlines only.