### PR TITLE
[bug/1] Fixed {{ticket}} placeholder

### DIFF
--- a/src/gitUtils.ts
+++ b/src/gitUtils.ts
@@ -422,8 +422,18 @@ export async function getCommitPrefix(gitRoot: string): Promise<string> {
  * Supports patterns like: feature/PROJ-123-description, PROJ-123, etc.
  */
 export function extractTicketFromBranch(branchName: string): string {
-    // Match patterns like PROJ-123, ABC-456, etc.
-    const match = branchName.match(/([A-Z]+-\d+)/);
+    const lastSeparator = Math.max(
+        branchName.lastIndexOf('-'),
+        branchName.lastIndexOf('_'),
+        branchName.lastIndexOf('/')
+    );
+
+    if (lastSeparator === -1 || lastSeparator >= branchName.length - 1) {
+        return '';
+    }
+
+    const suffix = branchName.slice(lastSeparator + 1);
+    const match = suffix.match(/(\d+)/);
     return match ? match[1] : '';
 }
 


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Fix ticket placeholder resolution by extracting only the numeric ID from the branch name suffix instead of the full ticket key.